### PR TITLE
Fix a bug in useFiles

### DIFF
--- a/src/main/kotlin/it/lamba/ktor/features/SinglePageApplication.kt
+++ b/src/main/kotlin/it/lamba/ktor/features/SinglePageApplication.kt
@@ -87,7 +87,7 @@ class SinglePageApplication(private val configuration: Configuration) {
         if (configuration.useFiles) {
             val file = configuration.fullPath().toFile()
             if (file.notExists()) throw FileNotFoundException("${configuration.fullPath()} not found")
-            call.respondFile(file, configuration.defaultPage)
+            call.respondFile(File(configuration.folderPath), configuration.defaultPage)
         } else {
             val indexPageApplication = call.resolveResource(configuration.fullPath().toString())
                 ?: throw FileNotFoundException("${configuration.fullPath()} not found")


### PR DESCRIPTION
If useFiles is on, the defaultPage is appended twice, once in configuration.fullPath() and once in configuration.defaultPage